### PR TITLE
Fixing PodSpec to use the new DexCare github repo

### DIFF
--- a/DexcareSDK/4.0.1/DexcareSDK.podspec
+++ b/DexcareSDK/4.0.1/DexcareSDK.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.license = 'private'
   s.authors = { 'Dexcare' => 'support@dexcarehealth.com'}
   s.source = {
-    :git => 'git@github.com:Health-V2-Consortium/DexCareSDK-iOS.git', :tag => "#{s.version}"
+    :git => 'git@github.com:DexCare/DexCareSDK-iOS.git', :tag => "#{s.version}"
   }
   s.module_name = 'DexcareSDK'
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }

--- a/DexcareSDK/4.0.1/DexcareSDK.podspec
+++ b/DexcareSDK/4.0.1/DexcareSDK.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.license = 'private'
   s.authors = { 'Dexcare' => 'support@dexcarehealth.com'}
   s.source = {
-    :git => 'git@github.com:DexCare/DexCareSDK-iOS.git', :tag => "#{s.version}"
+    :git => 'https://github.com/DexCare/DexCareSDK-iOS.git', :tag => "#{s.version}"
   }
   s.module_name = 'DexcareSDK'
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }

--- a/DexcareSDK/4.0.2/DexcareSDK.podspec
+++ b/DexcareSDK/4.0.2/DexcareSDK.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.license = 'private'
   s.authors = { 'Dexcare' => 'support@dexcarehealth.com'}
   s.source = {
-    :git => 'git@github.com:DexCare/PodSpec-iOS', :tag => "#{s.version}"
+    :git => 'git@github.com:DexCare/DexCareSDK-iOS.git', :tag => "#{s.version}"
   }
   s.module_name = 'DexcareSDK'
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }

--- a/DexcareSDK/4.0.2/DexcareSDK.podspec
+++ b/DexcareSDK/4.0.2/DexcareSDK.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.license = 'private'
   s.authors = { 'Dexcare' => 'support@dexcarehealth.com'}
   s.source = {
-    :git => 'git@github.com:Health-V2-Consortium/DexCareSDK-iOS.git', :tag => "#{s.version}"
+    :git => 'git@github.com:DexCare/PodSpec-iOS', :tag => "#{s.version}"
   }
   s.module_name = 'DexcareSDK'
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }

--- a/DexcareSDK/4.0.2/DexcareSDK.podspec
+++ b/DexcareSDK/4.0.2/DexcareSDK.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.license = 'private'
   s.authors = { 'Dexcare' => 'support@dexcarehealth.com'}
   s.source = {
-    :git => 'git@github.com:DexCare/DexCareSDK-iOS.git', :tag => "#{s.version}"
+    :git => 'https://github.com/DexCare/DexCareSDK-iOS.git', :tag => "#{s.version}"
   }
   s.module_name = 'DexcareSDK'
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }


### PR DESCRIPTION
We switched to the new public PodSpec https://github.com/DexCare/PodSpec-iOS/ but our build was not successful since the PodSpec was not updated to reference the new DexCare repository for iOS SDK.

I included the fixes for the Dexcare 4.0.1 and 4.0.2.